### PR TITLE
Exceptions not being honored during Update [Fixed]

### DIFF
--- a/NoRM/Collections/MongoCollectionGeneric.cs
+++ b/NoRM/Collections/MongoCollectionGeneric.cs
@@ -159,6 +159,15 @@ namespace Norm.Collections
 
             var um = new UpdateMessage<X, U>(_connection, FullyQualifiedName, ops, matchDocument, valueDocument);
             um.Execute();
+
+            if (_connection.StrictMode)
+            {
+                var error = _db.LastError(_connection.VerifyWriteCount);
+                if (error.Code > 0)
+                {
+                    throw new MongoException(error.Error);
+                }
+            }
         }
 
         public void Update<X>(X matchDocument, Action<IModifierExpression<T>> action, bool updateMultiple, bool upsert)


### PR DESCRIPTION
Upon update, errors such as unique index violations are not being 
propagated to client code.  With Mongo in verbose mode, the exceptions 
are indeed occurring on the server side, and the update is failing, 
but the failure mode just isn't being reported by NoRM and the update 
itself is failing. 

Errors are propagated correctly upon insert.  Reading through 
MongoCollectionGeneric.cs, in the Insert method, the following block 
of code is executed immediately after the insert is made: 

if (_connection.StrictMode) 
            { 
                var error = _db.LastError(); 
                if (error.Code > 0) 
                { 
                    throw new MongoException(error.Error); 
                } 
            } 
Yet this block is not found after the update is made via the Update 
method of the same class.  I wonder if there's a reason for this or 
simply an oversight?  Thanks! 

Stephen
