### PR TITLE
Unstable

### DIFF
--- a/NoRM.Tests/MongoCollectionTests.cs
+++ b/NoRM.Tests/MongoCollectionTests.cs
@@ -384,6 +384,84 @@ namespace Norm.Tests
             }
         }
 
+
+
+        [Test]
+        public void when_inserting_a_new_entity_with_int_id_equals_zero_generates_a_key()
+        {
+            using (var mongo = Mongo.Create(TestHelper.ConnectionString()))
+            {
+                var testint = new IntId {Name = "first"} ;
+                mongo.GetCollection<IntId>("Fake").Insert(testint);
+
+                Assert.NotNull(testint.Id);
+                Assert.AreNotEqual(0, testint.Id);
+            }
+        }
+
+        [Test]
+        public void when_inserting_a_22_new_entities_with_int_id_equals_zero_generates_a_unique_key_for_each_of_them()
+        {
+            using (var mongo = Mongo.Create(TestHelper.ConnectionString()))
+            {
+                var idents = new List<int>();
+                for (int i = 0; i <22; i++)
+                {
+                    var testint = new IntId() ;
+                    mongo.GetCollection<IntId>("Fake").Insert(testint);
+                    idents.Add(testint.Id);
+                }
+
+                var list = mongo.GetCollection<IntId>("Fake").Find(new { _id = Q.In(idents.ToArray()) });
+
+                foreach (var item in list)
+                {
+                    Assert.True(idents.Contains(item.Id));
+                }
+
+                Assert.AreEqual(idents.Distinct().Count(), list.Select(x => x.Id).Distinct().Count());
+            }
+        }
+
+
+        [Test]
+        public void when_inserting_a_new_entity_with_long_type_id_equals_zero_generates_a_key()
+        {
+            using (var mongo = Mongo.Create(TestHelper.ConnectionString()))
+            {
+                var testint = new LongId() { Name = "first" };
+                mongo.GetCollection<LongId>("Fake").Insert(testint);
+
+                Assert.NotNull(testint.Id);
+                Assert.AreNotEqual(0, testint.Id);
+            }
+        }
+
+        [Test]
+        public void when_inserting_a_22_new_entities_with_long_type_id_equals_zero_generates_a_unique_key_for_each_of_them()
+        {
+            using (var mongo = Mongo.Create(TestHelper.ConnectionString()))
+            {
+                var idents = new List<long>();
+                for (int i = 0; i < 22; i++)
+                {
+                    var testint = new LongId();
+                    mongo.GetCollection<LongId>("Fake").Insert(testint);
+                    idents.Add(testint.Id);
+                }
+
+                var list = mongo.GetCollection<LongId>("Fake").Find(new { _id = Q.In(idents.ToArray()) });
+
+                foreach (var item in list)
+                {
+                    Assert.True(idents.Contains(item.Id));
+                }
+
+                Assert.AreEqual(idents.Distinct().Count(), list.Select(x => x.Id).Distinct().Count());
+            }
+        }
+
+
         [Test]
         public void InsertingANewEntityWithNullableIntGeneratesAKeyComplex()
         {
@@ -520,6 +598,8 @@ namespace Norm.Tests
             }
         }
 
+        
+
         private class StringIdentifier
         {
             [MongoIdentifier]
@@ -530,6 +610,12 @@ namespace Norm.Tests
         private class IntId
         {
             public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class LongId
+        {
+            public long Id { get; set; }
             public string Name { get; set; }
         }
     }

--- a/NoRM.Tests/MongoConfigurationTests.cs
+++ b/NoRM.Tests/MongoConfigurationTests.cs
@@ -227,6 +227,40 @@ namespace Norm.Tests
         }
 
         [Test]
+        public void should_ignore_name_property_when_inserting__as_specified_in_mappings()
+        {
+
+            MongoConfiguration.Initialize(c => c.AddMap<ShopperMapWithIgnoreImmutableAndIgnoreIfNullConfigurationForProperties>());
+            using (
+                Shoppers shoppers =
+                    new Shoppers(Mongo.Create(TestHelper.ConnectionString("pooling=false", "test", null, null))))
+            {
+                shoppers.Drop<Shopper>();
+                shoppers.Add(new Shopper
+                                 {
+                                     Id = ObjectId.NewObjectId(),
+                                     Name = "John",
+                                 
+                                 });
+
+                shoppers.Add(new Shopper
+                                 {
+                                     Id = ObjectId.NewObjectId(),
+                                     Name = "Jane",
+                                   
+                                 });
+
+               
+                var deepQuery = shoppers.ToList();
+
+                Assert.IsNull(deepQuery[0].Name);
+                Assert.IsNull(deepQuery[1].Name);
+
+               
+            }
+        }
+
+        [Test]
         public void Can_correctly_determine_collection_name()
         {
             var collectionName = MongoConfiguration.GetCollectionName(typeof(SuperClassObject));

--- a/NoRM.Tests/TestClasses.cs
+++ b/NoRM.Tests/TestClasses.cs
@@ -879,6 +879,25 @@ namespace Norm.Tests
         }
     }
 
+    public class ShopperMapWithIgnoreImmutableAndIgnoreIfNullConfigurationForProperties:MongoConfigurationMap
+    {
+        public ShopperMapWithIgnoreImmutableAndIgnoreIfNullConfigurationForProperties()
+        {
+            For<Shopper>(
+                config=> config.ForProperty(x => x.Name).Ignore()
+                );
+
+            For<Cart>(
+                config=>
+                    {
+
+                        config.ForProperty(x => x.Product).IgnoreIfNull();
+                        config.ForProperty(x => x.Name).Immutable();
+
+                    }
+                );
+        }
+    }
     internal class IdMap0
     {
         public ObjectId _ID { get; set; }

--- a/NoRM/BSON/MagicProperty.cs
+++ b/NoRM/BSON/MagicProperty.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using Norm.Attributes;
 using System.ComponentModel;
+using Norm.Configuration;
 
 namespace Norm.BSON
 {
@@ -27,8 +28,11 @@ namespace Norm.BSON
         public MagicProperty(PropertyInfo property, Type declaringType)
         {
             _property = property;
-            this.IgnoreIfNull = property.GetCustomAttributes(_ignoredIfNullType, true).Length > 0;
-            this.Immutable = property.GetCustomAttributes(_immutableType, true).Length > 0;
+            this.IgnoreIfNull = property.GetCustomAttributes(_ignoredIfNullType, true).Length > 0 ||
+                MongoConfiguration.IsPropertyIgnoredWhenNull(declaringType,property.Name);
+            this.Immutable = property.GetCustomAttributes(_immutableType, true).Length > 0 ||
+                MongoConfiguration.IsPropertyImmutable(declaringType,property.Name);
+
             var props = property.GetCustomAttributes(_defaultValueType, true);
             if (props.Length > 0)
             {

--- a/NoRM/BSON/ReflectionHelper.cs
+++ b/NoRM/BSON/ReflectionHelper.cs
@@ -244,7 +244,8 @@ namespace Norm.BSON
             foreach (var property in properties)
             {
                 if (property.GetCustomAttributes(_ignoredType, true).Length > 0 ||
-                    property.GetIndexParameters().Length > 0)
+                    property.GetIndexParameters().Length > 0||
+                    MongoConfiguration.IsPropertyIgnored(property.DeclaringType,property.Name))
                 {
                     continue;
                 }

--- a/NoRM/Collections/CreateIndexExpression.cs
+++ b/NoRM/Collections/CreateIndexExpression.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq.Expressions;
+using Norm.BSON;
+using Norm.Configuration;
+using Norm.Protocol.Messages;
+
+namespace Norm.Collections
+{
+     class CreateIndexExpression<T> : ICreateIndexExpression<T>
+    {
+        public Expando Expando
+        {
+            get;
+            set;
+        }
+
+        public string CompoundName
+        {
+            get;
+            set;
+        }
+
+        public CreateIndexExpression()
+        {
+            Expando = new Expando();
+
+        }
+        public void Index(Expression<Func<T, object>> func, IndexOption indexDirection)
+        {
+            var propName = this.RecurseExpression(func.Body);
+            Expando[propName] = indexDirection;
+            CompoundName += propName + "_" + (int)indexDirection;
+
+        }
+        private String RecurseExpression(Expression body)
+        {
+            var me = body as MemberExpression;
+            if (me != null)
+            {
+                return this.RecurseMemberExpression(me);
+            }
+
+            var ue = body as UnaryExpression;
+            if (ue != null)
+            {
+                return this.RecurseExpression(ue.Operand);
+            }
+
+            throw new MongoException("Unknown expression type, expected a MemberExpression or UnaryExpression.");
+        }
+        private String RecurseMemberExpression(MemberExpression mex)
+        {
+            var retval = "";
+            var parentEx = mex.Expression as MemberExpression;
+            if (parentEx != null)
+            {
+                //we need to recurse because we're not at the root yet.
+                retval += this.RecurseMemberExpression(parentEx) + ".";
+            }
+            retval += MongoConfiguration.GetPropertyAlias(mex.Expression.Type, mex.Member.Name);
+            return retval;
+        }
+
+    }
+
+    public interface ICreateIndexExpression<T>
+    {
+        // Methods
+        void Index(Expression<Func<T, object>> func, IndexOption indexDirection);
+
+        // Properties
+        string CompoundName { get; set; }
+        Expando Expando { get; set; }
+    }
+}

--- a/NoRM/Collections/MongoCollectionGeneric.cs
+++ b/NoRM/Collections/MongoCollectionGeneric.cs
@@ -554,6 +554,18 @@ namespace Norm.Collections
 			// else throw Exception? (Only 1 key can be used for geospatial index)
 		}
 
+
+
+
+        public void CreateCompoundIndex(Action<ICreateIndexExpression<T>> indexes, bool isUnique)
+        {
+            ICreateIndexExpression<T> expression = new CreateIndexExpression<T>();
+            indexes(expression);
+
+            this.CreateIndex(expression.Expando, expression.CompoundName, isUnique);
+
+        }
+
         /// <summary>
         /// Gets the distinct values for the specified fieldSelectionExpando.
         /// </summary>

--- a/NoRM/Configuration/IMongoConfigurationMap.cs
+++ b/NoRM/Configuration/IMongoConfigurationMap.cs
@@ -54,6 +54,13 @@ namespace Norm.Configuration
         /// </returns>
         string GetPropertyAlias(Type type, string propertyName);
 
+        bool IsPropertyIgnored(Type type, string propertyName);
+
+        bool IsPropertyIgnoredWhenNull(Type type, string propertyName);
+
+        bool IsPropertyImmutable(Type type, string propertyName);
+
+
         string GetTypeDescriminator(Type type);
     }
 }

--- a/NoRM/Configuration/IPropertyMappingExpression.cs
+++ b/NoRM/Configuration/IPropertyMappingExpression.cs
@@ -19,5 +19,21 @@ namespace Norm.Configuration
         /// The alias.
         /// </param>
         void UseAlias(string alias);
+
+        /// <summary>
+        /// Ignores property if the value is null.
+        /// </summary>
+        void IgnoreIfNull();
+        /// <summary>
+        /// Indicates that the BSON serializer should ignore property.
+        /// </summary>
+        void Ignore();
+
+        /// <summary>
+        /// Ignores property on updates, but not on inserts, i.e. this is write-once value
+        /// </summary>
+        /// 
+        void Immutable();
+
     }
 }

--- a/NoRM/Configuration/MongoConfiguration.cs
+++ b/NoRM/Configuration/MongoConfiguration.cs
@@ -103,6 +103,23 @@ namespace Norm.Configuration
             return _configuration != null ? _configuration.GetConfigurationMap().GetPropertyAlias(type, propertyName) : propertyName;
         }
 
+        public static bool IsPropertyIgnored(Type type, string propertyName)
+        {
+            return _configuration != null ? _configuration.GetConfigurationMap().IsPropertyIgnored(type, propertyName) : false;
+        }
+
+        public static bool IsPropertyIgnoredWhenNull(Type type, string propertyName)
+        {
+            return _configuration != null ? _configuration.GetConfigurationMap().IsPropertyIgnoredWhenNull(type, propertyName) : false;
+        }
+
+        public static bool IsPropertyImmutable(Type type, string propertyName)
+        {
+            return _configuration != null ? _configuration.GetConfigurationMap().IsPropertyImmutable(type, propertyName) : false;
+        }
+
+
+
         public static IBsonTypeConverter GetBsonTypeConverter(Type t)
         {
             return _configuration != null ? _configuration.GetTypeConverterFor(t) : null;

--- a/NoRM/Configuration/MongoConfigurationMap.cs
+++ b/NoRM/Configuration/MongoConfigurationMap.cs
@@ -126,7 +126,7 @@ namespace Norm.Configuration
             }
             else if (map.ContainsKey(type) && map[type].ContainsKey(propertyName))
             {
-                retval = map[type][propertyName].Alias;             
+                retval = map[type][propertyName].Alias??propertyName;             
             }
             else if (discriminator != null && discriminator != type )
             {
@@ -136,6 +136,41 @@ namespace Norm.Configuration
             }
             return retval;
         }
+
+        public bool IsPropertyIgnored(Type type, string propertyName)
+        {
+            var map = MongoTypeConfiguration.PropertyMaps;
+            var retValue = false;
+            if (map.ContainsKey(type) && map[type].ContainsKey(propertyName))
+            {
+                retValue = map[type][propertyName].IsIgnored;
+            }
+            return retValue;
+        }
+
+        public bool IsPropertyIgnoredWhenNull(Type type, string propertyName)
+        {
+            var map = MongoTypeConfiguration.PropertyMaps;
+            var retValue = false;
+            if (map.ContainsKey(type) && map[type].ContainsKey(propertyName))
+            {
+                retValue = map[type][propertyName].IsIgnoredWhenNull;
+            }
+            return retValue;
+        }
+
+        public bool IsPropertyImmutable(Type type, string propertyName)
+        {
+            var map = MongoTypeConfiguration.PropertyMaps;
+            var retValue = false;
+            if (map.ContainsKey(type) && map[type].ContainsKey(propertyName))
+            {
+                retValue = map[type][propertyName].IsImmutable;
+            }
+            return retValue;
+        }
+
+       
 
         /// <summary>
         /// Gets the fluently configured discriminator type string for a type.

--- a/NoRM/Configuration/MongoTypeConfiguration.cs
+++ b/NoRM/Configuration/MongoTypeConfiguration.cs
@@ -14,6 +14,7 @@ namespace Norm.Configuration
         private static readonly Dictionary<Type, Type> _summaryTypes = new Dictionary<Type, Type>();
         private static readonly Dictionary<Type, bool> _discriminatedTypes = new Dictionary<Type, bool>();
 
+
         /// <summary>
         /// Gets the property maps.
         /// </summary>

--- a/NoRM/Configuration/PropertyMappingExpression.cs
+++ b/NoRM/Configuration/PropertyMappingExpression.cs
@@ -1,4 +1,6 @@
 ﻿
+using System;
+
 namespace Norm.Configuration
 {
     /// <summary>
@@ -11,6 +13,9 @@ namespace Norm.Configuration
         /// </summary>
         /// <value>The alias.</value>
         internal string Alias { get; set; }
+        internal bool IsIgnored { get; set; }
+        internal bool IsIgnoredWhenNull { get; set; }
+        internal bool IsImmutable { get; set; }
 
         /// <summary>
         /// Gets or sets whether the property is the Id for the entity.
@@ -33,6 +38,21 @@ namespace Norm.Configuration
         public void UseAlias(string alias)
         {
             Alias = alias;
+        }
+
+        public void IgnoreIfNull()
+        {
+            IsIgnoredWhenNull = true;
+        }
+
+        public void Ignore()
+        {
+            IsIgnored = true;
+        }
+
+        public void Immutable()
+        {
+            IsImmutable = true;
         }
     }
 }


### PR DESCRIPTION
added support for not nullable int and long to be id property generated by HiLo when that property equals zero and added fluent mapping methods which allow specify in configurationmappings ignored/ignoredifnull/immutable properties instead of attributes
