### PR TITLE
async is a future reserved word in c#.  Changing variable to use isAsync instead of async.

### DIFF
--- a/NoRM/IMongoAdmin.cs
+++ b/NoRM/IMongoAdmin.cs
@@ -12,7 +12,7 @@ namespace Norm
         BuildInfoResponse BuildInfo();
         IMongoDatabase Database { get; }
         DroppedDatabaseResponse DropDatabase();
-        ForceSyncResponse ForceSync(bool async);
+        ForceSyncResponse ForceSync(bool isAsync);
         IEnumerable<DatabaseInfo> GetAllDatabases();
         IEnumerable<CurrentOperationResponse> GetCurrentOperations();
         int GetProfileLevel();

--- a/NoRM/MongoAdmin.cs
+++ b/NoRM/MongoAdmin.cs
@@ -182,12 +182,12 @@ namespace Norm
         /// <summary>
         /// Request that the server write any uncommitted writes to the filesystem.
         /// </summary>
-        /// <param retval="async">if set to <c>true</c> [async].</param>
+        /// <param retval="isAsync">if set to <c>true</c> [async].</param>
         /// <returns></returns>
-        public ForceSyncResponse ForceSync(bool async)
+        public ForceSyncResponse ForceSync(bool isAsync)
         {
             AssertConnectedToAdmin();
-            return this.Database.GetCollection<ForceSyncResponse>("$cmd").FindOne(new { fsync = 1d, async });
+            return this.Database.GetCollection<ForceSyncResponse>("$cmd").FindOne(new { fsync = 1d, isAsync });
         }
 
         /// <summary>


### PR DESCRIPTION
This will fix any issues that occur if people have the Visual Studio Async CTP installed.  http://msdn.microsoft.com/en-us/vstudio/async.aspx
