### PR TITLE
Fix for concrete-typed field projections

### DIFF
--- a/NoRM/Collections/CollectionSequenceIdGenerator.cs
+++ b/NoRM/Collections/CollectionSequenceIdGenerator.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Norm.Collections;
+
+namespace Norm.Collections
+{
+    /// <summary>
+    /// Generates an identity using the HiLo algorithm per collection
+    /// </summary>
+    public class CollectionSequenceIdGenerator
+    {
+        private readonly object _generatorLock = new object();
+		private IDictionary<string, SequenceIdGenerator> _keyGeneratorsByTag = new Dictionary<string, SequenceIdGenerator>();
+
+    	/// <summary>
+    	/// Generates the identity value
+    	/// </summary>
+    	/// <param name="db">MongoDatabase instance</param>
+    	/// <param name="collectionName">Collection Name</param>
+    	/// <returns>Generated identity</returns>
+    	public long GenerateId(IMongoDatabase db, string collectionName)
+        {
+			SequenceIdGenerator value;
+
+            lock (_generatorLock)
+            {
+                if (_keyGeneratorsByTag.TryGetValue(collectionName, out value))
+                    return value.GenerateId(collectionName, db);
+
+				value = new SequenceIdGenerator();
+                // doing it this way for thread safety
+				_keyGeneratorsByTag = new Dictionary<string, SequenceIdGenerator>(_keyGeneratorsByTag)
+                {
+                    {collectionName, value}
+                };
+            }
+
+            return value.GenerateId(collectionName, db);
+        }
+    }
+}

--- a/NoRM/Collections/IMongoCollectionGeneric.cs
+++ b/NoRM/Collections/IMongoCollectionGeneric.cs
@@ -222,5 +222,11 @@ namespace Norm.Collections
         /// </summary>
         /// <returns>New identity value</returns>
         long GenerateId();
+
+    	/// <summary>
+    	/// Generates a new identity value using the Sequence Id generator
+    	/// </summary>
+    	/// <returns>New identity value</returns>
+    	long GenerateSequenceId();
     }
 }

--- a/NoRM/Collections/MongoCollectionGeneric.cs
+++ b/NoRM/Collections/MongoCollectionGeneric.cs
@@ -27,6 +27,7 @@ namespace Norm.Collections
     {
         private static Dictionary<int, object> _compiledTransforms = new Dictionary<int, object>();
         private static CollectionHiLoIdGenerator _collectionHiLoIdGenerator = new CollectionHiLoIdGenerator(20);
+		private static CollectionSequenceIdGenerator _collectionSequenceIdGenerator = new CollectionSequenceIdGenerator();
 
         /// <summary>
         /// This will have a different instance for each concrete version of <see cref="MongoCollection{T}"/>
@@ -595,5 +596,14 @@ namespace Norm.Collections
             return _collectionHiLoIdGenerator.GenerateId(_db, _collectionName);
         }
 
+
+		/// <summary>
+		/// Generates a new identity value using the Sequence Id generator
+		/// </summary>
+		/// <returns>New identity value</returns>
+		public long GenerateSequenceId()
+		{
+			return _collectionSequenceIdGenerator.GenerateId(_db, _collectionName);
+		}
     }
 }

--- a/NoRM/Collections/MongoCollectionGeneric.cs
+++ b/NoRM/Collections/MongoCollectionGeneric.cs
@@ -396,8 +396,20 @@ namespace Norm.Collections
                 var me = fieldSelection.Body as MemberExpression;
                 fieldSelectionExpando[me.GetPropertyAlias()] = 1;
             }
+            // Concrete typed expressions
+            else if (fieldSelection.Body is MemberInitExpression)
+            {
+                var initExpression = (fieldSelection.Body as MemberInitExpression);
+                foreach (var assignment in initExpression.Bindings.OfType<MemberAssignment>())
+                {
+                    if (assignment.Expression is MemberExpression)
+                    {
+                        var expression = assignment.Expression as MemberExpression;
+                        fieldSelectionExpando[expression.GetPropertyAlias()] = 1;
+                    }
+                }
+            }
             #endregion
-
 
             var qm = new QueryMessage<T, U>(_connection, fullName)
             {

--- a/NoRM/Collections/SequenceIdGenerator.cs
+++ b/NoRM/Collections/SequenceIdGenerator.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Norm.BSON;
+
+namespace Norm.Collections
+{
+	/// <summary>
+	/// Class that generates a new running number identity value for a collection
+	/// </summary>
+	public class SequenceIdGenerator
+	{
+		public static long? Seed { get; set; }
+
+		/// <summary>
+		/// Generates a new identity value
+		/// </summary>
+		/// <param name="collectionName">Collection Name</param>
+		/// <param name="database"></param>
+		/// <returns></returns>
+		public long GenerateId(string collectionName, IMongoDatabase database)
+		{
+			while (true)
+			{
+				try
+				{
+					var update = new Expando();
+					update["$inc"] = new {Next = 1};
+
+					var counter = database.GetCollection<SequenceIdCounters>().FindAndModify(new {_id = collectionName}, update);
+					
+					if (counter == null)
+					{
+						// account for starting seed
+						if (Seed != null)
+						{
+							database.GetCollection<SequenceIdCounters>()
+							.Insert(new SequenceIdCounters
+							{
+								CollectionName = collectionName,
+								Next = Seed.Value+1
+							});
+							return Seed.Value;
+						}
+
+						database.GetCollection<SequenceIdCounters>()
+							.Insert(new SequenceIdCounters
+							        	{
+							        		CollectionName = collectionName,
+											Next = 2
+							        	});
+						return 1;
+					}
+
+					var id = counter.Next;
+					return id;
+				}
+				catch (MongoException ex)
+				{
+					if (!ex.Message.Contains("duplicate key"))
+						throw;
+				}
+			}
+		}
+
+		#region Nested type: SequenceIdCounters
+
+		private class SequenceIdCounters
+		{
+			[MongoIdentifier]
+			public string CollectionName { get; set; }
+
+			public long Next { get; set; }
+		}
+
+		#endregion
+	}
+}

--- a/NoRM/NoRM.csproj
+++ b/NoRM/NoRM.csproj
@@ -107,6 +107,8 @@
     <Compile Include="BSON\ModifierCommand.cs" />
     <Compile Include="BSON\ReflectionHelper.cs" />
     <Compile Include="BSON\TypeConverters\CultureInfoTypeConverter.cs" />
+    <Compile Include="Collections\CollectionSequenceIdGenerator.cs" />
+    <Compile Include="Collections\SequenceIdGenerator.cs" />
     <Compile Include="Collections\CreateCollectionOptions.cs" />
     <Compile Include="Collections\IMongoCollectionGeneric.cs" />
     <Compile Include="Collections\MongoCollection.cs" />


### PR DESCRIPTION
As per: https://github.com/atheken/NoRM/issues#issue/64

Basically added an if to account for concrete-typed (MemberInitExpressions) expressions.
Profiling mongo now shows a lower _reslen_ when compared to non projected queries.
