### PR TITLE
Object must implement IConvertible exception

### DIFF
--- a/NoRM/Linq/MongoQueryProvider.cs
+++ b/NoRM/Linq/MongoQueryProvider.cs
@@ -75,6 +75,9 @@ namespace Norm.Linq
         /// <returns>Resulting object</returns>
         S IQueryProvider.Execute<S>(Expression expression)
         {
+            object result = ExecuteQuery<S>(expression);
+            if (result is IConvertible)
+                return (S)Convert.ChangeType(result, typeof(S));
             return (S)ExecuteQuery<S>(expression);
         }
 

--- a/NoRM/Linq/MongoQueryProvider.cs
+++ b/NoRM/Linq/MongoQueryProvider.cs
@@ -75,8 +75,7 @@ namespace Norm.Linq
         /// <returns>Resulting object</returns>
         S IQueryProvider.Execute<S>(Expression expression)
         {
-            object result = ExecuteQuery<S>(expression);
-            return (S)Convert.ChangeType(result, typeof(S));
+            return (S)ExecuteQuery<S>(expression);
         }
 
         /// <summary>


### PR DESCRIPTION
Object must implement IConvertible exception
Edit
See here for example of this exception:

http://stackoverflow.com/questions/4782022/polymorphism-problem-in-mongodb-with-norm-driver

The use of Convert.ChangeType on MongoQueryProvider line 79 was causing a run-time exception when retrieving a collection of a base type. In fact we can attempt a simple cast if the object does not implement IConvertible.
