### PR TITLE
Resolve the Generic Linq query when first generic parameter is not a complex object

### DIFF
--- a/NoRM/Linq/MongoQueryTranslator.cs
+++ b/NoRM/Linq/MongoQueryTranslator.cs
@@ -455,7 +455,17 @@ namespace Norm.Linq
                 graphParts[i] = MongoConfiguration.GetPropertyAlias(typeToQuery, graph[i]);
 
                 if (property.PropertyType.IsGenericType)
-                    typeToQuery = property.PropertyType.GetGenericArguments()[0];
+                {
+                    if (property.PropertyType.IsAssignableFrom(typeof(IEnumerable)))
+                    {
+                        typeToQuery = property.PropertyType.GetGenericArguments()[0];
+                    }
+                    else
+                    {
+                        typeToQuery = property.PropertyType;
+                    }
+
+                }
                 else
                     typeToQuery = property.PropertyType.HasElementType ? property.PropertyType.GetElementType() : property.PropertyType;
             }


### PR DESCRIPTION
Steps to reproduce:

class Reference<TKey, TType>{
    public TKey ID{get;set;}
    public string Type { get {return typeof(TType).Name;} set{ } }
}

class User{
    int ID{get;set;}
    string Name{get;set;}
    Reference<string, Language> Language{ get; set; }
}

var conn = mongo.Connect();
var listResult = from x in conn.FindAll()
    where x.Language.ID == "en-us" 
    select x;

var result = listResult.Any(); // an error is thrown in this moment (sequence does not contains any element)

The error is raised by de Visitors of MongoQueryTranslator.

Workaround (if not patched this commit into):
Change Reference<string, Language> to Reference<Language, string> and change behaviors of the application.
