### PR TITLE
Incresed max bson document size

### DIFF
--- a/NoRM/BSON/DocumentExceedsSizeLimitsException.cs
+++ b/NoRM/BSON/DocumentExceedsSizeLimitsException.cs
@@ -3,7 +3,7 @@
 namespace Norm.BSON
 {
     /// <summary>
-    /// An exception that can be thrown by MongoCollection when the document is more than the MongoDB limit of 4MB.
+    /// An exception that can be thrown by MongoCollection when the document is more than the MongoDB limit of 8MB.
     /// </summary>
     /// <typeparam retval="T">
     /// The type of the document that was serialized.

--- a/NoRM/Protocol/Messages/Message.cs
+++ b/NoRM/Protocol/Messages/Message.cs
@@ -7,7 +7,7 @@ namespace Norm.Protocol
     /// </summary>
     public class Message
     {
-        protected const int FOUR_MEGABYTES = 4 * 1024 * 1024;
+        protected const int EIGHT_MEGABYTES = 8 * 1024 * 1024;
         
         /// <summary>TODO::Description.</summary>
         protected string _collection;
@@ -44,7 +44,7 @@ namespace Norm.Protocol
         protected static byte[] GetPayload<X>(X data)
         {
             var payload = BsonSerializer.Serialize(data);
-            if (payload.Length > FOUR_MEGABYTES)
+            if (payload.Length > EIGHT_MEGABYTES)
             {
                 throw new DocumentExceedsSizeLimitsException<X>(data, payload.Length);
             }


### PR DESCRIPTION
Changed max bson document size to 8mb (the new internal limit of mongo db)
